### PR TITLE
Retaining the chat history.

### DIFF
--- a/src/core/assistant-message/index.ts
+++ b/src/core/assistant-message/index.ts
@@ -14,6 +14,7 @@ export const toolUseNames = [
 	"read_file",
 	"write_to_file",
 	"list_files",
+	"ask_followup_question",
 	"attempt_completion",
 ] as const;
 
@@ -53,6 +54,11 @@ export interface ReadFileToolUse extends ToolUse {
 export interface WriteToFileToolUse extends ToolUse {
 	name: "write_to_file";
 	params: Partial<Pick<Record<ToolParamName, string>, "path" | "content">>;
+}
+
+export interface AskFollowupQuestionToolUse extends ToolUse {
+	name: "ask_followup_question"
+	params: Partial<Pick<Record<ToolParamName, string>, "question">>
 }
 
 export interface AttemptCompletionToolUse extends ToolUse {

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -63,6 +63,15 @@ Your file content here
 </content>
 </write_to_file>
 
+## ask_followup_question
+Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+Parameters:
+- question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
+Usage:
+<ask_followup_question>
+<question>Your question here</question>
+</ask_followup_question>
+
 ## attempt_completion
 Description: After each tool use, the user will respond with the result of that tool use, i.e. if it succeeded or failed, along with any reasons for failure. Once you've received the results of tool uses and can confirm that the task is complete, use this tool to present the result of your work to the user. This tool is used to summarize the final outcome of the task.
 IMPORTANT NOTE: Before using this tool, you must ask yourself in <thinking></thinking> tags.
@@ -134,6 +143,7 @@ RULES
 - At the end of each user message, you will automatically receive environment_details. This information is not written by the user themselves, but is auto-generated to provide potentially relevant context about the project structure and environment. While this information can be valuable for understanding the project context, do not treat it as a direct part of the user's request or response. Use it to inform your actions and decisions, but don't assume the user is explicitly asking about or referring to this information unless they clearly do so in their message. When using environment_details, explain your actions clearly to ensure the user understands, as they may not be aware of these details.
 - Before executing commands, check the "Actively Running Terminals" section in environment_details. If present, consider how these active processes might impact your task. For example, if a local development server is already running, you wouldn't need to start it again. If no active terminals are listed, proceed with command execution as normal.
 - When using the write_to_file tool, ALWAYS provide the COMPLETE file content in your response. This is NON-NEGOTIABLE. Partial updates or placeholders like '// rest of code unchanged' are STRICTLY FORBIDDEN. You MUST include ALL parts of the file, even if they haven't been modified. Failure to do so will result in incomplete or broken code, severely impacting the user's project.
+- You are only allowed to ask the user questions using the ask_followup_question tool. Use this tool only when you need additional details to complete a task, and be sure to use a clear and concise question that will help you move forward with the task. However if you can use the available tools to avoid having to ask the user questions, you should do so. 
 - The last part of the response should include task completion to the user using the attempt_completion tool. You should always use this tool and provide output in the end.
 ====
 
@@ -152,6 +162,6 @@ You accomplish a given task, breaking it down into clear steps and working throu
 
 1. Analyze the user's task and set clear, achievable goals to accomplish it. Prioritize these goals in a logical order.
 2. Work through these goals sequentially, utilizing available tools one at a time as necessary. 
-3. Remember, you have extensive capabilities with access to a wide range of tools that can be used in powerful and clever ways as necessary to accomplish each goal. Before calling a tool, do some analysis within <thinking></thinking> tags. First, analyze the file structure provided in environment_details to gain context and insights for proceeding effectively. Then, think about which of the provided tools is the most relevant tool to accomplish the user's task.
+3. Remember, you have extensive capabilities with access to a wide range of tools that can be used in powerful and clever ways as necessary to accomplish each goal. Before calling a tool, do some analysis within <thinking></thinking> tags. First, analyze the file structure provided in environment_details to gain context and insights for proceeding effectively. Then, think about which of the provided tools is the most relevant tool to accomplish the user's task.Next, go through each of the required parameters of the relevant tool and determine if the user has directly provided or given enough information to infer a value. When deciding if the parameter can be inferred, carefully consider all the context to see if it supports a specific value. If all of the required parameters are present or can be reasonably inferred, close the thinking tag and proceed with the tool use. BUT, if one of the values for a required parameter is missing, DO NOT invoke the tool (not even with fillers for the missing params) and instead, ask the user to provide the missing parameters using the ask_followup_question tool. DO NOT ask for more information on optional parameters if it is not provided.
 4. Once you've completed the user's task, you must use the attempt_completion tool to present the result of the task to the user.
 `;

--- a/src/core/webview/DevAssistProvider.ts
+++ b/src/core/webview/DevAssistProvider.ts
@@ -123,9 +123,21 @@ export class DevAssistProvider implements vscode.WebviewViewProvider {
 					case "newTask":
 						await this.initNewTask(message.text);
 						break;
+					// case "askQuestion":
+					// 	// await this.askQuestion(message.text);
+					// 	await this.initNewTask(message.text);
+					// 	break;
 					case "askQuestion":
-						// await this.askQuestion(message.text);
-						await this.initNewTask(message.text);
+						switch (message.newTask) {
+							case true:
+								await this.initNewTask(message.text);
+								break;
+							case false:
+								await this.devAssist?.handleWebviewAskResponse(message);
+								break;
+						}
+
+						// this.devAssist?.handleWebviewAskResponse(message);
 						break;
 				}
 			},

--- a/webview-ui/src/components/chat/ChatContainer.tsx
+++ b/webview-ui/src/components/chat/ChatContainer.tsx
@@ -4,7 +4,7 @@ import UserMessage from "./UserMessage";
 
 const ChatContainer = () => {
 	const { showThinking, showToolInUse, assistantMessages } = useExtension();
-	console.log(assistantMessages);
+	// console.log(assistantMessages);
 	return (
 		// generate the chat container using the system message and user message components
 		<div style={{ width: "100%" }}>

--- a/webview-ui/src/components/chat/ChatInput.tsx
+++ b/webview-ui/src/components/chat/ChatInput.tsx
@@ -4,6 +4,7 @@ import { vscode } from "../../utils/vscode";
 import { useExtension } from "../../context/ExtensionContext";
 
 const ChatInput = ({scrollChatViewToBottom, ...props}: any) => {
+	const [newTask, setNewTask] = useState(true);
 	const [value, setValue] = useState("Create a python script for a simple calculator");
 
 	const { addAssistantMessage } = useExtension();
@@ -15,10 +16,12 @@ const ChatInput = ({scrollChatViewToBottom, ...props}: any) => {
 		vscode.postMessage({
 			type: "askQuestion",
 			// askResponse: "messageResponse",
+			newTask: newTask,
 			text: value,
 			// images,
 		});
 		setValue("");
+		setNewTask(false);
 	};
 
 	return (

--- a/webview-ui/src/context/ExtensionContext.tsx
+++ b/webview-ui/src/context/ExtensionContext.tsx
@@ -21,8 +21,7 @@ export const ExtensionContextProvider: React.FC<{ children: React.ReactNode }> =
 		assistantMessages: { [key: string]: any }[];
 		taskHistory: any[];
 	}>({
-		assistantMessages: [{ role: "assistant", content: "Hi! I am DevAssistAI. test test test test test test test test test test test test " },
-			{ role: "User", content: "Hi! I am DevAssistAI. test test test test test test test test test test test test " }
+		assistantMessages: [{ role: "assistant", content: "Hi! I am DevAssistAI. " },
 		],
 		taskHistory: [],
 	});

--- a/webview-ui/src/context/ExtensionContext.tsx
+++ b/webview-ui/src/context/ExtensionContext.tsx
@@ -21,7 +21,9 @@ export const ExtensionContextProvider: React.FC<{ children: React.ReactNode }> =
 		assistantMessages: { [key: string]: any }[];
 		taskHistory: any[];
 	}>({
-		assistantMessages: [{ role: "assistant", content: "Hi! I am DevAssistAI." }],
+		assistantMessages: [{ role: "assistant", content: "Hi! I am DevAssistAI. test test test test test test test test test test test test " },
+			{ role: "User", content: "Hi! I am DevAssistAI. test test test test test test test test test test test test " }
+		],
 		taskHistory: [],
 	});
 
@@ -34,7 +36,7 @@ export const ExtensionContextProvider: React.FC<{ children: React.ReactNode }> =
 
 	const handleMessage = useCallback((event: MessageEvent) => {
 		const message: any = event.data;
-		console.log("message", message);
+		// console.log("message", message);
 		switch (message.type) {
 			// case "state": {
 			// 	setState(message.state!);
@@ -73,6 +75,10 @@ export const ExtensionContextProvider: React.FC<{ children: React.ReactNode }> =
 					show: false,
 					tool: "",
 				});
+				break;
+			}
+			case "askFollowup": {
+				console.log("partialMessage *******", message);
 				break;
 			}
 		}


### PR DESCRIPTION
This PR introduces the following key updates:  

1. **`ask_followup_Question` Tool**  
   - Added a new tool, `ask_followup_Question`, enabling the LLM to ask follow-up questions when the user's prompt is unclear.  

2. **Chat Retention Feature**  
   - Implemented a feature to retain the chat context.  
   - Each user-assistant conversation will now be passed to the LLM for context in subsequent requests.  

### Testing  
- Tested successfully with Gemini.  

### Known Issues  
- Occasionally, XML tags are retained in the content while parsing messages.  
  - **Possible Solution**: Further tuning of `system.ts` and additional checks during data parsing may be required to resolve this issue.  

